### PR TITLE
Don't verify topic match if it wasn't set

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function validateRequest(options, message, callback) {
         arn = message.TopicArn.split(':'),
         region = arn[3];
 
-    if (options.topic !== message.TopicArn) {
+    if (options.topic && options.topic !== message.TopicArn) {
         callback(new Error('Topic ARN does not match, expected ' + options.topic + ' got ' + message.TopicArn));
         return;
     }


### PR DESCRIPTION
In my use case we don't really need to verify particular topics.
